### PR TITLE
Turn signal trace support added for conditional models.

### DIFF
--- a/vista/core/core_utils/TopicNames.py
+++ b/vista/core/core_utils/TopicNames.py
@@ -19,6 +19,7 @@ class TopicNames:
     speed = 'speed'
     distance = 'distance'
     lidar_3d = 'lidar_3d'
+    turn_signal = 'turn_signal'
 
     BADVAL = ['BADVAL']  # for denoting topics we don't know yet
 

--- a/vista/entities/agents/Car.py
+++ b/vista/entities/agents/Car.py
@@ -84,6 +84,7 @@ class Car(Entity):
         self._tire_angle: float = 0.
         self._human_speed: float = 0.
         self._human_curvature: float = 0.
+        self._human_turn_signal: int = 1
         self._human_steering: float = 0.
         self._human_tire_angle: float = 0.
         self._timestamp: float = 0.
@@ -193,6 +194,7 @@ class Car(Entity):
         # Reset states and dynamics
         self._human_speed = self.trace.f_speed(self.timestamp)
         self._human_curvature = self.trace.f_curvature(self.timestamp)
+        self._human_turn_signal = int(self.trace.f_turn_signal(self.timestamp))
         self._human_steering = curvature2steering(self.human_curvature,
                                                   self.wheel_base,
                                                   self.steering_ratio)
@@ -277,6 +279,7 @@ class Car(Entity):
 
             self._human_speed = self.trace.f_speed(self.timestamp)
             self._human_curvature = self.trace.f_curvature(self.timestamp)
+            self._human_turn_signal = int(self.trace.f_turn_signal(self.timestamp))
             self._human_steering = curvature2steering(self.human_curvature,
                                                       self.wheel_base,
                                                       self.steering_ratio)
@@ -410,6 +413,7 @@ class Car(Entity):
         # Update human control based on current timestamp
         self._human_speed = self.trace.f_speed(self.timestamp)
         self._human_curvature = self.trace.f_curvature(self.timestamp)
+        self._human_turn_signal = int(self.trace.f_turn_signal(self.timestamp))
         self._human_steering = curvature2steering(self.human_curvature,
                                                   self.wheel_base,
                                                   self.steering_ratio)
@@ -523,6 +527,11 @@ class Car(Entity):
     def human_curvature(self) -> float:
         """ Curvature of human trajectory in current timestamp. """
         return self._human_curvature
+
+    @property
+    def human_turn_signal(self) -> int:
+        """ Speed of human turn signal in current timestamp. """
+        return self._human_turn_signal
 
     @property
     def human_steering(self) -> float:


### PR DESCRIPTION
Added support for conditional models into vista. All changes are backward compatible and using the turn signals is optional. I also looked into extending Vista in UT-ADL/vista-evaluation repository, so that the base code could be left unchanged, but the code is not very extensible, primarily due to World class.